### PR TITLE
fix: Apply different regexp for checking zip locations when using multihost

### DIFF
--- a/src/converter/devfile-converter.ts
+++ b/src/converter/devfile-converter.ts
@@ -706,7 +706,7 @@ export class DevfileConverter {
         const location = project.zip.location;
         // if matching a pattern, then update the location
         const regex =
-          /https:\/\/(?<name>.*?)-(?<namespace>.*?)\.(?<subdomain>.*)\/devfile-registry\/resources\/(?<resourcelink>.*)/gm;
+          /https:\/\/(devfile-registry|codeready|eclipse-che)-(?<namespace>.*?)\.(?<subdomain>.*)[\/.*]*\/resources\/(?<resourcelink>.*)/gm;
         let m: RegExpExecArray = regex.exec(location);
         if (m !== null) {
           const namespace = m.groups.namespace;

--- a/tests/_data/devfile-vertx-zip-v1.yaml
+++ b/tests/_data/devfile-vertx-zip-v1.yaml
@@ -2,10 +2,14 @@ apiVersion: 1.0.0
 metadata:
   generateName: vertx-http-booster-
 projects:
-  - name: vertx-http-booster
+  - name: vertx-http-booster1
     source:
       type: zip
       location: 'https://codeready-codeready-workspaces-operator.apps.sandbox-m2.ll9k.p1.openshiftapps.com/devfile-registry/resources/vertx-http-booster-vertx-http-booster-master.zip'
+  - name: vertx-http-booster2
+    source:
+      type: zip
+      location: 'https://devfile-registry-openshift-workspaces.apps.crw-airgap-v10.crw-qe.com/resources/vertx-health-checks-vertx-health-checks-example-redhat-master.zip'
 components:
   - id: redhat/java11/latest
     type: chePlugin

--- a/tests/converter/devfile-converter.spec.ts
+++ b/tests/converter/devfile-converter.spec.ts
@@ -691,10 +691,14 @@ describe('Test Devfile converter', () => {
 
     // grab locations
     const locations = convertedDevfileV2?.projects?.map(project => project.zip.location);
-    expect(locations.length).toBe(1);
-    const location = locations[0];
-    expect(location).toBe(
+    expect(locations.length).toBe(2);
+    const location1 = locations[0];
+    expect(location1).toBe(
       'http://devfile-registry.codeready-workspaces-operator.svc:8080/resources/vertx-http-booster-vertx-http-booster-master.zip'
+    );
+    const location2 = locations[1];
+    expect(location2).toBe(
+      'http://devfile-registry.openshift-workspaces.svc:8080/resources/vertx-health-checks-vertx-health-checks-example-redhat-master.zip'
     );
   });
 });


### PR DESCRIPTION


Change-Id: Icfd5ab1b982e10b34d944ed8e932bfe6d94e651d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>